### PR TITLE
fix: HTML-safe serialization of island props and transfer state

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@huuma/ui",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": {
     ".": "./src/mod.ts",
     "./v-node": "./src/v-node/mod.ts",

--- a/src/platform/server/inline-json.test.ts
+++ b/src/platform/server/inline-json.test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertThrows } from "@std/assert";
+
+import { inlineJSON } from "./inline-json.ts";
+
+Deno.test(inlineJSON.name, async (t) => {
+  await t.step("serializes a normal object exactly as JSON.stringify does", () => {
+    const value = { a: 1, b: "text", c: true, d: null };
+    assertEquals(inlineJSON(value), JSON.stringify(value));
+  });
+
+  await t.step("serializes arrays and primitives like JSON.stringify", () => {
+    assertEquals(inlineJSON([1, 2, 3]), "[1,2,3]");
+    assertEquals(inlineJSON("plain"), '"plain"');
+    assertEquals(inlineJSON(42), "42");
+    assertEquals(inlineJSON(null), "null");
+  });
+
+  await t.step("escapes every literal < and contains no raw <", () => {
+    const value = { html: "</script><script>" };
+    const result = inlineJSON(value);
+
+    assertEquals(result.includes("<"), false);
+    assertEquals(
+      result,
+      JSON.stringify(value).replaceAll("<", "\\u003C"),
+    );
+  });
+
+  await t.step("escapes </script> and <!-- without a literal <", () => {
+    const value = { a: "</script>", b: "<!--" };
+    const result = inlineJSON(value);
+
+    assertEquals(result.includes("<"), false);
+    assertEquals(result.includes("</script>"), false);
+    assertScriptDataSafe(result);
+  });
+
+  await t.step("escapes U+2028 and U+2029", () => {
+    const value = { ls: "\u2028", ps: "\u2029", mix: "a\u2028b\u2029c" };
+    const result = inlineJSON(value);
+
+    assertEquals(result.includes("\u2028"), false);
+    assertEquals(result.includes("\u2029"), false);
+  });
+
+  await t.step("round-trips losslessly for every escaping case", () => {
+    const value = {
+      close: "</script>",
+      comment: "<!--",
+      open: "<script>",
+      combined: "<!--<script></script>",
+      ls: "\u2028",
+      ps: "\u2029",
+      nested: { deep: "</script>\u2028<!--" },
+      arr: ["</script>", "\u2029", "<!--<script>"],
+      normal: "plain text with no special chars",
+    };
+
+    assertEquals(JSON.parse(inlineJSON(value)), value);
+  });
+
+  await t.step("round-trips a normal object unchanged", () => {
+    const value = { greeting: "Hello World!", count: 7 };
+    assertEquals(JSON.parse(inlineJSON(value)), value);
+  });
+
+  await t.step("throws TypeError for unsupported top-level values", () => {
+    assertThrows(() => inlineJSON(undefined), TypeError);
+    assertThrows(() => inlineJSON(() => {}), TypeError);
+    assertThrows(() => inlineJSON(Symbol("s")), TypeError);
+  });
+
+  await t.step("propagates JSON.stringify errors unchanged", () => {
+    // Circular reference throws a TypeError from JSON.stringify.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    assertThrows(() => inlineJSON(circular), TypeError);
+
+    // BigInt throws a TypeError from JSON.stringify.
+    assertThrows(() => inlineJSON(BigInt(1)), TypeError);
+  });
+});
+
+// A script-data payload is safe when no literal `<` remains: every
+// sequence that can terminate or change the parser state of an inline
+// script element begins with `<`.
+function assertScriptDataSafe(serialized: string): void {
+  assertEquals(
+    serialized.includes("<"),
+    false,
+    `expected no literal "<" in serialized script data: ${serialized}`,
+  );
+}

--- a/src/platform/server/inline-json.test.ts
+++ b/src/platform/server/inline-json.test.ts
@@ -3,10 +3,13 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { inlineJSON } from "./inline-json.ts";
 
 Deno.test(inlineJSON.name, async (t) => {
-  await t.step("serializes a normal object exactly as JSON.stringify does", () => {
-    const value = { a: 1, b: "text", c: true, d: null };
-    assertEquals(inlineJSON(value), JSON.stringify(value));
-  });
+  await t.step(
+    "serializes a normal object exactly as JSON.stringify does",
+    () => {
+      const value = { a: 1, b: "text", c: true, d: null };
+      assertEquals(inlineJSON(value), JSON.stringify(value));
+    },
+  );
 
   await t.step("serializes arrays and primitives like JSON.stringify", () => {
     assertEquals(inlineJSON([1, 2, 3]), "[1,2,3]");
@@ -32,7 +35,6 @@ Deno.test(inlineJSON.name, async (t) => {
 
     assertEquals(result.includes("<"), false);
     assertEquals(result.includes("</script>"), false);
-    assertScriptDataSafe(result);
   });
 
   await t.step("escapes U+2028 and U+2029", () => {
@@ -80,14 +82,3 @@ Deno.test(inlineJSON.name, async (t) => {
     assertThrows(() => inlineJSON(BigInt(1)), TypeError);
   });
 });
-
-// A script-data payload is safe when no literal `<` remains: every
-// sequence that can terminate or change the parser state of an inline
-// script element begins with `<`.
-function assertScriptDataSafe(serialized: string): void {
-  assertEquals(
-    serialized.includes("<"),
-    false,
-    `expected no literal "<" in serialized script data: ${serialized}`,
-  );
-}

--- a/src/platform/server/inline-json.ts
+++ b/src/platform/server/inline-json.ts
@@ -9,8 +9,10 @@
 // Escaping every literal `<` as the JavaScript escape \u003C is
 // sufficient because every sequence that can terminate or change the
 // parser state of script data begins with `<`. U+2028 and U+2029 are
-// also escaped because they are valid JSON but invalid in JavaScript
-// string literals. The parsed value is unchanged; only the bytes the
+// escaped defensively: ES2019 made both legal inside JavaScript string
+// literals, so the module script this feeds is fine either way, but
+// they remain hazardous if the payload is ever re-embedded or consumed
+// by an older parser. The parsed value is unchanged; only the bytes the
 // HTML tokenizer sees change.
 //
 // This must NOT be routed through the HTML entity escaping path: script

--- a/src/platform/server/inline-json.ts
+++ b/src/platform/server/inline-json.ts
@@ -1,0 +1,35 @@
+// Serialize JSON for embedding inside an inline <script> element.
+//
+// HTML tokenization does not honor JavaScript string quoting: the first
+// `</script>` sequence (or the sequences that enter the tokenizer's
+// script-data-escaped states, which both begin with `<`) terminates or
+// derails the script element. JSON.stringify alone therefore cannot be
+// used to interpolate application data into a raw-text element.
+//
+// Escaping every literal `<` as the JavaScript escape \u003C is
+// sufficient because every sequence that can terminate or change the
+// parser state of script data begins with `<`. U+2028 and U+2029 are
+// also escaped because they are valid JSON but invalid in JavaScript
+// string literals. The parsed value is unchanged; only the bytes the
+// HTML tokenizer sees change.
+//
+// This must NOT be routed through the HTML entity escaping path: script
+// content uses the HTML raw-text parsing mode and does not decode
+// character references, so HTML entities would corrupt the JavaScript.
+
+export function inlineJSON(value: unknown): string {
+  // JSON.stringify returns undefined for top-level values it cannot
+  // represent (undefined, functions, symbols). Emitting the JavaScript
+  // identifier `undefined` or silently coercing to null would change
+  // the value, so throw instead to give the function an honest return
+  // type.
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    throw new TypeError("inlineJSON: value is not JSON-serializable");
+  }
+
+  return json
+    .replaceAll("<", "\\u003C")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}

--- a/src/platform/server/scripts.test.tsx
+++ b/src/platform/server/scripts.test.tsx
@@ -20,7 +20,11 @@ const BODY = { runtime: RUNTIME, islands: [], entryPoints: [] };
 function makeIsland(props: Record<string, unknown>, id = "island1"): Island {
   // Spread: jsx() mutates the props object it receives (it assigns
   // children), so a fresh copy keeps the caller's expected value pristine.
-  return { id, path: ISLAND_SCRIPT.path, node: jsx(IslandComponent, { ...props }) };
+  return {
+    id,
+    path: ISLAND_SCRIPT.path,
+    node: jsx(IslandComponent, { ...props }),
+  };
 }
 
 // Render Launch to its full <script>...</script> string.
@@ -49,13 +53,21 @@ function scriptSource(html: string): string {
   return html.slice(open + 1, close);
 }
 
-// Read a balanced JSON value beginning at `start`, honoring string
-// literals and escapes. Returns the parsed value.
+// Read a balanced JSON object or array beginning at `start`, honoring
+// string literals and escapes so that braces inside string data do not
+// affect the depth count. Both payloads Launch emits (island props and
+// the transfer state) are objects, so no primitive scanning is needed.
 function parseJsonValue(source: string, start: number): unknown {
   let i = start;
   while (i < source.length && /\s/.test(source[i])) i++;
 
   const valueStart = i;
+  if (source[i] !== "{" && source[i] !== "[") {
+    throw new Error(
+      `expected a JSON object or array at ${start}, got ${source[i]}`,
+    );
+  }
+
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -82,9 +94,6 @@ function parseJsonValue(source: string, start: number): unknown {
       if (depth === 0) {
         return JSON.parse(source.slice(valueStart, i + 1));
       }
-    }
-    if (depth === 0 && /[,;)\]}]/.test(ch)) {
-      return JSON.parse(source.slice(valueStart, i));
     }
   }
   throw new Error(`unterminated JSON value at ${start}`);
@@ -131,15 +140,18 @@ Deno.test("Launch inline script serialization", async (t) => {
     },
   );
 
-  await t.step("escapes </script> in a prop and keeps the payload safe", async () => {
-    const html = await renderLaunch([makeIsland({ danger: "</script>" })]);
-    assertStringIncludes(
-      html,
-      "\\u003C/script>",
-      "expected </script> to be escaped in the serialized props",
-    );
-    assertScriptDataSafe(scriptSource(html));
-  });
+  await t.step(
+    "escapes </script> in a prop and keeps the payload safe",
+    async () => {
+      const html = await renderLaunch([makeIsland({ danger: "</script>" })]);
+      assertStringIncludes(
+        html,
+        "\\u003C/script>",
+        "expected </script> to be escaped in the serialized props",
+      );
+      assertScriptDataSafe(scriptSource(html));
+    },
+  );
 
   await t.step("covers <!-- followed by <script in prop data", async () => {
     const value = { a: "<!--<script>", b: "<!--", c: "<script>" };
@@ -176,7 +188,9 @@ Deno.test("Launch inline script serialization", async (t) => {
   await t.step(
     "leaves normal prop serialization unchanged from previous output",
     async () => {
-      const html = await renderLaunch([makeIsland({ greeting: "Hello World!" })]);
+      const html = await renderLaunch([
+        makeIsland({ greeting: "Hello World!" }),
+      ]);
       const src = scriptSource(html);
       assertStringIncludes(src, `props: {"greeting":"Hello World!"}`);
       assertEquals(parseProps(src), { greeting: "Hello World!" });
@@ -192,12 +206,15 @@ Deno.test("Launch inline script serialization", async (t) => {
     assertScriptDataSafe(scriptSource(html));
   });
 
-  await t.step("covers <!-- followed by <script in transfer state", async () => {
-    const value = { a: "<!--<script>", b: "<!--", c: "<script>" };
-    const html = await renderLaunch([makeIsland({ a: 1 })], value);
-    assertScriptDataSafe(scriptSource(html));
-    assertEquals(parseTransferState(scriptSource(html)), value);
-  });
+  await t.step(
+    "covers <!-- followed by <script in transfer state",
+    async () => {
+      const value = { a: "<!--<script>", b: "<!--", c: "<script>" };
+      const html = await renderLaunch([makeIsland({ a: 1 })], value);
+      assertScriptDataSafe(scriptSource(html));
+      assertEquals(parseTransferState(scriptSource(html)), value);
+    },
+  );
 
   await t.step("covers U+2028 and U+2029 in transfer state", async () => {
     const value = { ls: "\u2028", ps: "\u2029", mix: "x\u2028y\u2029z" };
@@ -208,21 +225,26 @@ Deno.test("Launch inline script serialization", async (t) => {
     assertEquals(parseTransferState(src), value);
   });
 
-  await t.step("round-trips transfer state exactly after JSON.parse", async () => {
-    const value = {
-      close: "</script>",
-      comment: "<!--",
-      open: "<script>",
-      combined: "<!--<script></script>",
-      ls: "\u2028",
-      ps: "\u2029",
-      nested: { deep: "</script>\u2028<!--" },
-      arr: ["</script>", "\u2029", "<!--<script>"],
-      normal: "plain",
-    };
-    const src = scriptSource(await renderLaunch([makeIsland({ a: 1 })], value));
-    assertEquals(parseTransferState(src), value);
-  });
+  await t.step(
+    "round-trips transfer state exactly after JSON.parse",
+    async () => {
+      const value = {
+        close: "</script>",
+        comment: "<!--",
+        open: "<script>",
+        combined: "<!--<script></script>",
+        ls: "\u2028",
+        ps: "\u2029",
+        nested: { deep: "</script>\u2028<!--" },
+        arr: ["</script>", "\u2029", "<!--<script>"],
+        normal: "plain",
+      };
+      const src = scriptSource(
+        await renderLaunch([makeIsland({ a: 1 })], value),
+      );
+      assertEquals(parseTransferState(src), value);
+    },
+  );
 
   await t.step(
     "dangerous props and transfer state together add no literal </script>",
@@ -247,8 +269,8 @@ Deno.test("Launch inline script serialization", async (t) => {
       const html = await renderLaunch([makeIsland({ a: 1 })]);
       const src = scriptSource(html);
       assertStringIncludes(src, "const transferState = {};");
-      assertStringIncludes(src, "import { launch } from \"/runtime.js\";");
-      assertStringIncludes(src, "import $I1 from \"/island.js\";");
+      assertStringIncludes(src, 'import { launch } from "/runtime.js";');
+      assertStringIncludes(src, 'import $I1 from "/island.js";');
       assertStringIncludes(src, "launch([");
       assertStringIncludes(src, "], transferState);");
     },

--- a/src/platform/server/scripts.test.tsx
+++ b/src/platform/server/scripts.test.tsx
@@ -1,0 +1,256 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+import type { JSX } from "../../jsx-runtime/mod.ts";
+import { jsx } from "../../jsx-runtime/mod.ts";
+import type { Island } from "../../islands/islands.ts";
+import { Launch } from "./scripts.ts";
+import { renderToString } from "./render.ts";
+
+// A dummy island component so Launch can read a component node's props.
+function IslandComponent(_props: JSX.ComponentProps): JSX.Element {
+  return null;
+}
+
+const RUNTIME = { path: "runtime.js", name: "runtime" };
+const ISLAND_SCRIPT = { path: "island.js", name: "island" };
+const BODY = { runtime: RUNTIME, islands: [], entryPoints: [] };
+
+// Build an Island whose node carries the given props (children are
+// stripped by Launch, mirroring real island bootstrap).
+function makeIsland(props: Record<string, unknown>, id = "island1"): Island {
+  // Spread: jsx() mutates the props object it receives (it assigns
+  // children), so a fresh copy keeps the caller's expected value pristine.
+  return { id, path: ISLAND_SCRIPT.path, node: jsx(IslandComponent, { ...props }) };
+}
+
+// Render Launch to its full <script>...</script> string.
+async function renderLaunch(
+  islands: Island[],
+  transferState?: unknown,
+  nonce = "n0nce",
+): Promise<string> {
+  return await renderToString(
+    Launch({
+      body: BODY,
+      nonce,
+      islands,
+      // deno-lint-ignore no-explicit-any
+      transferState: transferState as any,
+    }),
+    {},
+  );
+}
+
+// Extract the inner JavaScript source of the launch <script> element,
+// i.e. the bytes the HTML tokenizer sees as script data.
+function scriptSource(html: string): string {
+  const open = html.indexOf(">");
+  const close = html.lastIndexOf("</script>");
+  return html.slice(open + 1, close);
+}
+
+// Read a balanced JSON value beginning at `start`, honoring string
+// literals and escapes. Returns the parsed value.
+function parseJsonValue(source: string, start: number): unknown {
+  let i = start;
+  while (i < source.length && /\s/.test(source[i])) i++;
+
+  const valueStart = i;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{" || ch === "[") depth++;
+    if (ch === "}" || ch === "]") {
+      depth--;
+      if (depth === 0) {
+        return JSON.parse(source.slice(valueStart, i + 1));
+      }
+    }
+    if (depth === 0 && /[,;)\]}]/.test(ch)) {
+      return JSON.parse(source.slice(valueStart, i));
+    }
+  }
+  throw new Error(`unterminated JSON value at ${start}`);
+}
+
+// Extract and parse the `props: <json>` payload from an island entry.
+function parseProps(source: string): Record<string, unknown> {
+  const marker = "props: ";
+  const idx = source.indexOf(marker);
+  return parseJsonValue(source, idx + marker.length) as Record<
+    string,
+    unknown
+  >;
+}
+
+// Extract and parse the `const transferState = <json>;` assignment.
+function parseTransferState(source: string): unknown {
+  const marker = "const transferState = ";
+  const idx = source.indexOf(marker);
+  return parseJsonValue(source, idx + marker.length);
+}
+
+// A script-data payload is safe when no literal `<` remains inside it:
+// every sequence that can terminate or change the parser state of an
+// inline script element begins with `<`.
+function assertScriptDataSafe(inner: string): void {
+  assertEquals(
+    inner.includes("<"),
+    false,
+    `expected no literal "<" in serialized script data: ${inner}`,
+  );
+}
+
+Deno.test("Launch inline script serialization", async (t) => {
+  await t.step(
+    "renders exactly one literal </script> for the launch element",
+    async () => {
+      const html = await renderLaunch(
+        [makeIsland({ greeting: "</script>" })],
+        { note: "</script>" },
+      );
+      // Only the element's own closing tag should appear.
+      assertEquals(html.split("</script>").length - 1, 1);
+    },
+  );
+
+  await t.step("escapes </script> in a prop and keeps the payload safe", async () => {
+    const html = await renderLaunch([makeIsland({ danger: "</script>" })]);
+    assertStringIncludes(
+      html,
+      "\\u003C/script>",
+      "expected </script> to be escaped in the serialized props",
+    );
+    assertScriptDataSafe(scriptSource(html));
+  });
+
+  await t.step("covers <!-- followed by <script in prop data", async () => {
+    const value = { a: "<!--<script>", b: "<!--", c: "<script>" };
+    const html = await renderLaunch([makeIsland(value)]);
+    assertScriptDataSafe(scriptSource(html));
+    assertEquals(parseProps(scriptSource(html)), value);
+  });
+
+  await t.step("covers U+2028 and U+2029 in prop data", async () => {
+    const value = { ls: "\u2028", ps: "\u2029", mix: "x\u2028y\u2029z" };
+    const html = await renderLaunch([makeIsland(value)]);
+    const src = scriptSource(html);
+    assertEquals(src.includes("\u2028"), false);
+    assertEquals(src.includes("\u2029"), false);
+    assertEquals(parseProps(src), value);
+  });
+
+  await t.step("round-trips props exactly after JSON.parse", async () => {
+    const value = {
+      close: "</script>",
+      comment: "<!--",
+      open: "<script>",
+      combined: "<!--<script></script>",
+      ls: "\u2028",
+      ps: "\u2029",
+      nested: { deep: "</script>\u2028<!--" },
+      arr: ["</script>", "\u2029", "<!--<script>"],
+      normal: "plain",
+    };
+    const src = scriptSource(await renderLaunch([makeIsland(value)]));
+    assertEquals(parseProps(src), value);
+  });
+
+  await t.step(
+    "leaves normal prop serialization unchanged from previous output",
+    async () => {
+      const html = await renderLaunch([makeIsland({ greeting: "Hello World!" })]);
+      const src = scriptSource(html);
+      assertStringIncludes(src, `props: {"greeting":"Hello World!"}`);
+      assertEquals(parseProps(src), { greeting: "Hello World!" });
+    },
+  );
+
+  await t.step("escapes </script> in transfer state", async () => {
+    const html = await renderLaunch(
+      [makeIsland({ a: 1 })],
+      { note: "</script>" },
+    );
+    assertStringIncludes(html, "\\u003C/script>");
+    assertScriptDataSafe(scriptSource(html));
+  });
+
+  await t.step("covers <!-- followed by <script in transfer state", async () => {
+    const value = { a: "<!--<script>", b: "<!--", c: "<script>" };
+    const html = await renderLaunch([makeIsland({ a: 1 })], value);
+    assertScriptDataSafe(scriptSource(html));
+    assertEquals(parseTransferState(scriptSource(html)), value);
+  });
+
+  await t.step("covers U+2028 and U+2029 in transfer state", async () => {
+    const value = { ls: "\u2028", ps: "\u2029", mix: "x\u2028y\u2029z" };
+    const html = await renderLaunch([makeIsland({ a: 1 })], value);
+    const src = scriptSource(html);
+    assertEquals(src.includes("\u2028"), false);
+    assertEquals(src.includes("\u2029"), false);
+    assertEquals(parseTransferState(src), value);
+  });
+
+  await t.step("round-trips transfer state exactly after JSON.parse", async () => {
+    const value = {
+      close: "</script>",
+      comment: "<!--",
+      open: "<script>",
+      combined: "<!--<script></script>",
+      ls: "\u2028",
+      ps: "\u2029",
+      nested: { deep: "</script>\u2028<!--" },
+      arr: ["</script>", "\u2029", "<!--<script>"],
+      normal: "plain",
+    };
+    const src = scriptSource(await renderLaunch([makeIsland({ a: 1 })], value));
+    assertEquals(parseTransferState(src), value);
+  });
+
+  await t.step(
+    "dangerous props and transfer state together add no literal </script>",
+    async () => {
+      const html = await renderLaunch(
+        [makeIsland({ danger: "</script>" })],
+        { danger: "</script><!--<script>" },
+      );
+      assertEquals(html.split("</script>").length - 1, 1);
+      assertScriptDataSafe(scriptSource(html));
+      const src = scriptSource(html);
+      assertEquals(parseProps(src), { danger: "</script>" });
+      assertEquals(parseTransferState(src), {
+        danger: "</script><!--<script>",
+      });
+    },
+  );
+
+  await t.step(
+    "absent transfer state still emits {} and preserves launch structure",
+    async () => {
+      const html = await renderLaunch([makeIsland({ a: 1 })]);
+      const src = scriptSource(html);
+      assertStringIncludes(src, "const transferState = {};");
+      assertStringIncludes(src, "import { launch } from \"/runtime.js\";");
+      assertStringIncludes(src, "import $I1 from \"/island.js\";");
+      assertStringIncludes(src, "launch([");
+      assertStringIncludes(src, "], transferState);");
+    },
+  );
+});

--- a/src/platform/server/scripts.ts
+++ b/src/platform/server/scripts.ts
@@ -5,6 +5,7 @@ import type { Island } from "../../islands/islands.ts";
 
 import type { TransferState } from "./transfer-state.ts";
 import type { PageScripts, Script } from "./app.ts";
+import { inlineJSON } from "./inline-json.ts";
 
 interface ScriptsProps extends JSX.ComponentProps {
   scripts?: { entryPoints: Script[] };
@@ -64,14 +65,14 @@ export function Launch(
     const { children: _, ...props } =
       (<JSX.ComponentNode<JSX.Component>> island.node).props;
     _islands.push(
-      `{fn: $I${i}, props: ${JSON.stringify(props)}, islandId: "${island.id}"}`,
+      `{fn: $I${i}, props: ${inlineJSON(props)}, islandId: "${island.id}"}`,
     );
 
     i++;
   }
 
   templates.push(
-    `const transferState = ${JSON.stringify(transferState ?? {})};`,
+    `const transferState = ${inlineJSON(transferState ?? {})};`,
   );
   nodes.push("\n");
 


### PR DESCRIPTION
Island props and transfer state were embedded into the inline launch <script> via bare JSON.stringify. HTML tokenization ignores JavaScript string quoting, so a literal </script> sequence inside prop data terminated the script element, truncating the launch module and preventing hydration.

Add inlineJSON, a context-specific serializer that escapes every literal < as \u003C and U+2028/U+2029 as \u2028/\u2029, sufficient because every sequence that can terminate or derail script data begins with <. Use it for both the island props and transferState interpolations in Launch. The parsed value is unchanged; only the bytes the HTML tokenizer sees change. The ordinary HTML entity escaping path is untouched.

This is not routed through @std/html/entities: script content uses the HTML raw-text parsing mode and does not decode character references, so HTML escaping would corrupt the JavaScript source.